### PR TITLE
Introduce "assemblies" and deprecate "assembly" in manifests

### DIFF
--- a/cmd/dump_project.go
+++ b/cmd/dump_project.go
@@ -38,16 +38,22 @@ var parseManifestCmd = &cobra.Command{
 	},
 }
 
-func dumpMavenAssemblies(p project.Project) []string {
-	dependencies := make([]string, 0)
+func dumpMavenAssemblies(p project.Project) map[string][]string {
+	assemblies := make(map[string][]string)
 
 	project.ForEachModuleOrSubmodules(p, func(module project.Module) {
-		if module.IsMavenModule() && module.Assembly {
-			dependencies = append(dependencies, fmt.Sprintf("%s:%s", module.GroupId(), module.ArtifactId()))
+		if module.IsMavenModule() && len(module.Assemblies) > 0 {
+			for _, assemblyId := range module.Assemblies {
+				if module.AssemblyAttachment != "" {
+					assemblies[assemblyId] = append(assemblies[assemblyId], fmt.Sprintf("%s:%s:%s", module.GroupId(), module.ArtifactId(), module.AssemblyAttachment))
+				} else {
+					assemblies[assemblyId] = append(assemblies[assemblyId], fmt.Sprintf("%s:%s", module.GroupId(), module.ArtifactId()))
+				}
+			}
 		}
 	})
 
-	return dependencies
+	return assemblies
 }
 
 func init() {

--- a/project/project.go
+++ b/project/project.go
@@ -29,8 +29,8 @@ type Module struct {
 	Path               string
 	Repository         string
 	Revision           string
-	Assembly           bool
-	AssemblyDescriptor string
+	Assemblies         []string
+	AssemblyAttachment string
 	Server             bool
 	Submodules         []Module
 	apply              Apply
@@ -178,8 +178,8 @@ func New(config config.Config, manifestFiles []string, options ...projectOption)
 					Path:               path,
 					Repository:         moduleRepository,
 					Revision:           module.Revision,
-					Assembly:           submodule.Assembly,
-					AssemblyDescriptor: module.AssemblyDescriptor,
+					Assemblies:         submodule.Assemblies,
+					AssemblyAttachment: submodule.AssemblyAttachment,
 				})
 			}
 		}
@@ -205,8 +205,8 @@ func New(config config.Config, manifestFiles []string, options ...projectOption)
 			Path:               path,
 			Repository:         moduleRepository,
 			Revision:           module.Revision,
-			Assembly:           module.Assembly,
-			AssemblyDescriptor: module.AssemblyDescriptor,
+			Assemblies:         module.Assemblies,
+			AssemblyAttachment: module.AssemblyAttachment,
 			Server:             module.Server,
 			Submodules:         submodules,
 			apply:              moduleApply,


### PR DESCRIPTION
The "assembly" boolean field was used to decide if a module should be
included in the open-source assembly descriptor. The enterprise assembly
descriptor included a hard coded list of plugins and wasn't generated like
the open-source descriptor.

We need to be able to generate the enterprise assembly descriptor as well
because we now have different artifacts in 2.4 and 3.0, for example.

To do this, we introduced the "assemblies" field which contains a list of
assembly descriptor IDs. The open-souce and enterprise assembly descriptor
templates now get a list of modules for a given assembly ID.

    // graylog-assembly.xml
    {{ range $assembly := index .Assemblies "graylog" }}
      // ...
    {{ end }}

    // graylog-enterprise-assembly.xml
    {{ range $assembly := index .Assemblies "graylog-enterprise" }}
      // ...
    {{ end }}

This makes it possible to configure one or more assemblies for each
module in the manifest. It also allows us to include each module in more
than one assembly.

The CLI tool will emit a warning for manifests which still use the old
"assembly" field.