### PR TITLE
Rewrite NameFromRepository

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Graylog2/graylog-project-cli/logger"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -76,14 +77,12 @@ func GetAbsolutePath(path string) string {
 }
 
 func NameFromRepository(repository string) string {
-	if strings.HasPrefix(repository, "https://") {
-		return strings.Replace(strings.Split(strings.TrimPrefix(repository, "https://"), "/")[2], ".git", "", 1)
-	} else if strings.HasPrefix(repository, "git@") {
-		return strings.Replace(strings.Split(repository, "/")[1], ".git", "", 1)
-	} else {
+	index := strings.Index(repository, "/")
+	if index == -1 {
 		logger.Fatal("Unable to get name from repository: %s", repository)
 	}
-	return ""
+
+	return strings.Replace(path.Base(repository[index:]), ".git", "", 1)
 }
 
 func ConvertGithubGitToHTTPS(repository string) string {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -8,6 +8,14 @@ import (
 const sshRepo = "git@github.com:Graylog2/graylog2-server.git"
 const httpsRepo = "https://github.com/Graylog2/graylog2-server.git"
 
+var repos = [...]string {
+	"git@github.com:Graylog2/graylog2-server.git",
+	"https://github.com/Graylog2/graylog2-server.git",
+	"user@example.org:External/Graylog2/graylog2-server.git",
+	"https://example.org/External/Graylog2/graylog2-server.git",
+	"file:///home/user/Graylog2/graylog2-server",
+}
+
 func TestNameFromRepository(t *testing.T) {
 	expected := "graylog2-server"
 
@@ -19,6 +27,14 @@ func TestNameFromRepository(t *testing.T) {
 	httpsRepoName := utils.NameFromRepository(httpsRepo)
 	if httpsRepoName != expected {
 		t.Errorf("Repository %s does not resolve to name %s - result: `%s`", httpsRepo, expected, httpsRepoName)
+	}
+
+
+	for _, repo := range repos {
+		repoName := utils.NameFromRepository(repo)
+		if repoName != expected {
+			t.Errorf("Repository %s does not resolve to name %s - result: `%s`", repo, expected, repoName)
+		}
 	}
 }
 


### PR DESCRIPTION
NameFromRepository now extracts the name of a repository from a wider range of repo urls. It is now more permissive towards invalid/incorrect urls.

The test case has been extended.

This closes #6