### PR TITLE
Override repository-root for all commands in CI environments

### DIFF
--- a/cmd/checkout.go
+++ b/cmd/checkout.go
@@ -70,12 +70,6 @@ func prepareCheckoutCommand(cmd *cobra.Command, args []string) (c.Config, *repo.
 
 	config := c.Merge(defaultConfig)
 
-	// We use a special repository root if running in a CI environment and the default hasn't been changed.
-	if config.IsCI() && config.RepositoryRoot == c.DefaultRepositoryRoot {
-		logger.Info("Running in a CI environment, using repository root: %s", c.CIRepositoryRoot)
-		config.RepositoryRoot = c.CIRepositoryRoot
-	}
-
 	repoManager := repo.NewRepoManager(config)
 
 	logger.Debug("Using manifests: %v", config.Checkout.ManifestFiles)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,6 +65,12 @@ Example usage:
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		logger.SetDebug(viper.GetBool("debug"))
 		logger.SetPrefix(viper.GetString("logger-prefix"))
+
+		// We use a special repository root if running in a CI environment and the default hasn't been changed.
+		if config.IsCI() && viper.GetString("repository-root") == config.DefaultRepositoryRoot {
+			logger.Info("Running in a CI environment, using repository root: %s", config.CIRepositoryRoot)
+			viper.Set("repository-root", config.CIRepositoryRoot)
+		}
 	},
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -34,7 +34,7 @@ type Config struct {
 }
 
 // Returns true if running a CI environment. Detected environments: Jenkins, TravisCI
-func (c Config) IsCI() bool {
+func IsCI() bool {
 	return os.Getenv("CI") != "" || os.Getenv("TRAVIS") != "" || os.Getenv("BUILD_ID") != ""
 }
 


### PR DESCRIPTION
Previously we only did it for the checkout command.

Fixes the following issue in CI environments:

```
$ graylog-project status
Current project status
  Manifests: [manifests/master.json]
  Module versions
Skipping module graylog2-server because it does not exist yet
Skipping module graylog-plugin-collector because it does not exist yet
Skipping module graylog-plugin-aws because it does not exist yet
Skipping module graylog-plugin-threatintel because it does not exist yet
Skipping module graylog-plugin-integrations because it does not exist yet
```