### PR TITLE
Use the actual executable name in usage output.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/Graylog2/graylog-project-cli/config"
 	"github.com/Graylog2/graylog-project-cli/logger"
@@ -27,7 +28,7 @@ var forceHttpsRepos bool
 
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
-	Use:   "graylog-project-cli",
+	Use:   filepath.Base(os.Args[0]),
 	Short: "graylog-project management CLI",
 	Long: `
 CLI tool to manage a graylog-project setup


### PR DESCRIPTION
The executable might be named differently than `graylog-project-cli` (e.g. https://github.com/Graylog2/graylog-project shows renaming to `graylog-project`).

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

