### PR TITLE
Also print commit ids with the status command

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -46,7 +46,7 @@ func statusCommand(cmd *cobra.Command, args []string) {
 			continue
 		}
 		utils.InDirectory(module.Path, func() {
-			commitId := git.GitValue("rev-parse", "HEAD")
+			commitId := git.GitValue("rev-parse", "--short", "HEAD")
 			revision := git.GitValue("rev-parse", "--abbrev-ref", "HEAD")
 			gitStatus := git.GitValue("status", "--porcelain")
 			filesModified, filesDeleted, filesAdded := 0, 0, 0

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -46,6 +46,7 @@ func statusCommand(cmd *cobra.Command, args []string) {
 			continue
 		}
 		utils.InDirectory(module.Path, func() {
+			commitId := git.GitValue("rev-parse", "HEAD")
 			revision := git.GitValue("rev-parse", "--abbrev-ref", "HEAD")
 			gitStatus := git.GitValue("status", "--porcelain")
 			filesModified, filesDeleted, filesAdded := 0, 0, 0
@@ -64,19 +65,19 @@ func statusCommand(cmd *cobra.Command, args []string) {
 			}
 
 			if !module.HasParent() {
-				logger.Info("    %-"+strconv.Itoa(int(maxNameLength))+"s  %s (branch: %s)", module.Name, module.Version(), revision)
+				logger.Info("    %-"+strconv.Itoa(int(maxNameLength))+"s  %s (commit: %s, branch: %s)", module.Name, module.Version(), commitId, revision)
 				if config.Verbose {
 					logger.ColorInfo(color.FgYellow, "        <no parent>")
 				}
 			} else {
 				if config.Verbose {
-					logger.Info("    %-"+strconv.Itoa(int(maxNameLength))+"s  %s (branch: %s)", module.Name, module.Version(), revision)
+					logger.Info("    %-"+strconv.Itoa(int(maxNameLength))+"s  %s (commit: %s, branch: %s)", module.Name, module.Version(), commitId, revision)
 					logger.ColorInfo(color.FgYellow, "        Parent groupId:      %s", module.ParentGroupId())
 					logger.ColorInfo(color.FgYellow, "        Parent artifactId:   %s", module.ParentArtifactId())
 					logger.ColorInfo(color.FgYellow, "        Parent version:      %s", module.ParentVersion())
 					logger.ColorInfo(color.FgYellow, "        Parent relativePath: %s", module.ParentRelativePath())
 				} else {
-					logger.Info("    %-"+strconv.Itoa(int(maxNameLength))+"s  %s (branch: %s, parent: %s)", module.Name, module.Version(), revision, module.ParentVersion())
+					logger.Info("    %-"+strconv.Itoa(int(maxNameLength))+"s  %s (commit: %s, branch: %s, parent: %s)", module.Name, module.Version(), commitId, revision, module.ParentVersion())
 				}
 			}
 			if !config.Verbose && (filesModified > 0 || filesDeleted > 0 || filesAdded > 0) {

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"strconv"
 
-	"github.com/Graylog2/graylog-project-cli/config"
+	c "github.com/Graylog2/graylog-project-cli/config"
 	"github.com/Graylog2/graylog-project-cli/git"
 	"github.com/Graylog2/graylog-project-cli/logger"
 	"github.com/Graylog2/graylog-project-cli/manifest"
@@ -29,7 +29,7 @@ func init() {
 }
 
 func statusCommand(cmd *cobra.Command, args []string) {
-	config := config.Get()
+	config := c.Get()
 	manifestFiles := manifest.ReadState().Files()
 	project := p.New(config, manifestFiles)
 
@@ -46,7 +46,14 @@ func statusCommand(cmd *cobra.Command, args []string) {
 			continue
 		}
 		utils.InDirectory(module.Path, func() {
-			commitId := git.GitValue("rev-parse", "--short", "HEAD")
+			var commitId string
+			if c.IsCI() {
+				// Don't display shortened commit IDs in CI environments to avoid future ambiguities regarding the
+				// shortened commit IDs
+				commitId = git.GitValue("rev-parse", "HEAD")
+			} else  {
+				commitId = git.GitValue("rev-parse", "--short", "HEAD")
+			}
 			revision := git.GitValue("rev-parse", "--abbrev-ref", "HEAD")
 			gitStatus := git.GitValue("status", "--porcelain")
 			filesModified, filesDeleted, filesAdded := 0, 0, 0


### PR DESCRIPTION
That makes it easier to identify if a build
contained a certain change or not.


new output:
```
Current project status
  Manifests: [manifests/master.json]
  Module versions
    graylog-parent                          4.3.0-SNAPSHOT (commit: 8f71197851615a0ba26f7b2ba8bfe14d37a839b8, branch: master)
        Git status: 2 modified
    graylog-plugin-collector                4.3.0-SNAPSHOT (commit: 6d34e7080458df2b8fc02ff80427adea43ff5172, branch: master, parent: 4.3.0-SNAPSHOT)
        Git status: 1 modified
    graylog-plugin-aws                      4.3.0-SNAPSHOT (commit: 3203a3e4c92b22ff27c39841a1f8c5064efc72bb, branch: master, parent: 4.3.0-SNAPSHOT)
        Git status: 1 modified
    graylog-plugin-threatintel              4.3.0-SNAPSHOT (commit: 8c1962e7b38da189097a66a1f9244d105cefbc10, branch: master, parent: 4.3.0-SNAPSHOT)
        Git status: 1 modified
    graylog-plugin-enterprise-parent        4.3.0-SNAPSHOT (commit: e288eeab171ce90f1356bbb70b486a7fff821271, branch: master, parent: 4.3.0-SNAPSHOT)
        Git status: 2 modified
    graylog-plugin-enterprise-integrations  4.3.0-SNAPSHOT (commit: ba721dee3bd22c18d62f1163a247bbce04a1753d, branch: master, parent: 4.3.0-SNAPSHOT)
        Git status: 1 modified
    graylog-plugin-integrations             4.3.0-SNAPSHOT (commit: 334a301756fbee84595e9e72f2d03da80be28725, branch: master, parent: 4.3.0-SNAPSHOT)
        Git status: 1 modified
```
