### PR TITLE
Adding better bin_dir default location for dev in IntelliJ

### DIFF
--- a/idea/setup.go
+++ b/idea/setup.go
@@ -20,6 +20,7 @@ var runConfigurations = map[string]string{
   <configuration default="false" name="Graylog Server" type="Application" factoryName="Application" singleton="true">
     <envs>
       <env name="DEVELOPMENT" value="true" />
+      <env name="GRAYLOG_BIN_DIR" value="../graylog-plugin-enterprise/enterprise/bin" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="org.graylog2.bootstrap.Main" />
     <module name="runner" />


### PR DESCRIPTION
The reporting binaries are checked now during preflight so they should exist in dev environments (they do after a `mvn package`) but we should point to them by default, too.



see https://github.com/Graylog2/graylog-plugin-enterprise/pull/7090

## Notes for Reviewers

- [ ] The commit history must be preserved - please use the rebase-merge or standard merge option instead of squash-merge
- [ ] Sync up with the author before merging

