### PR TITLE
Allow overriding name of a repository

### DIFF
--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -20,6 +20,7 @@ type Manifest struct {
 }
 
 type ManifestModule struct {
+	Name               string           `json:"name,omitempty"`
 	Repository         string           `json:"repository,omitempty"`
 	Revision           string           `json:"revision,omitempty"`
 	Maven              string           `json:"maven,omitempty"`

--- a/project/project.go
+++ b/project/project.go
@@ -185,7 +185,7 @@ func New(config config.Config, manifestFiles []string, options ...projectOption)
 	}
 
 	for _, module := range readManifest.Modules {
-		moduleName := utils.NameFromRepository(module.Repository)
+		moduleName, _ := utils.FirstNonEmpty(module.Name, utils.NameFromRepository(module.Repository))
 		moduleRepository := module.Repository
 		submodules := make([]Module, 0)
 


### PR DESCRIPTION
By specifying a "name" in the manifest, the repository will be checked out under the given name instead of auto-detecting the name from the repository name.

This is helpful when a fork of the graylog2-server repository is used. The Graylog project build relies on the server repository being checked out as
"graylog2-server".

Without this change, a repository
"Graylog2/graylog2-server-fork.git" would be checked out as "graylog2-server-fork".

With this change, it can be named "graylog2-server" with the git remote still pointing at
"Graylog2/graylog2-server-fork.git".

